### PR TITLE
Add switch control on module_adapter

### DIFF
--- a/tools/topology/topology1/m4/codec_adapter.m4
+++ b/tools/topology/topology1/m4/codec_adapter.m4
@@ -52,7 +52,10 @@ define(`W_CODEC_ADAPTER',
 `	bytes ['
 		$6
 `	]'
-
+`ifelse(`$#', `7',
+`	mixer ['
+		$7
+`	]',)'
 `}')
 
 divert(0)dnl

--- a/tools/topology/topology1/sof/pipe-codec-adapter-playback.m4
+++ b/tools/topology/topology1/sof/pipe-codec-adapter-playback.m4
@@ -12,6 +12,7 @@ include(`dai.m4')
 include(`pipeline.m4')
 include(`codec_adapter.m4')
 include(`bytecontrol.m4')
+include(`mixercontrol.m4')
 
 #
 # Controls
@@ -61,6 +62,22 @@ C_CONTROLBYTES(CA_SETUP_CONTROLBYTES_NAME_PIPE, PIPELINE_ID,
 	,
 	CA_SETUP_CONFIG)
 
+# For codec developers, rename bytes control names if necessary.
+ifdef(`CA_SWITCH_NAME',`',
+	`define(`CA_SWITCH_NAME', `CA Enable')')
+
+define(CA_SWITCH_NAME_PIPE, concat(CA_SWITCH_NAME, PIPELINE_ID))
+define(`CONTROL_NAME', `CA_SWITCH_NAME_PIPE')
+C_CONTROLMIXER(CA_SWITCH_NAME_PIPE, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 259 binds the mixer control to switch get/put handlers, 259, 259),
+	CONTROLMIXER_MAX(max 1 indicates switch type control, 1),
+	false,
+	,
+	Channel register and shift for Front Center,
+	LIST(`	', KCONTROL_CHANNEL(FC, 3, 0)),
+	"1")
+undefine(`CONTROL_NAME')
+
 #
 # Components and Buffers
 #
@@ -74,7 +91,8 @@ ifdef(`CA_SCHEDULE_CORE',`', `define(`CA_SCHEDULE_CORE', `SCHEDULE_CORE')')
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, DAI_PERIODS, 0, SCHEDULE_CORE)
 
 W_CODEC_ADAPTER(0, PIPELINE_FORMAT, DAI_PERIODS, DAI_PERIODS, CA_SCHEDULE_CORE,
-        LIST(`          ', "CA_SETUP_CONTROLBYTES_NAME_PIPE"))
+        LIST(`          ', "CA_SETUP_CONTROLBYTES_NAME_PIPE"),
+	LIST(`          ', "CA_SWITCH_NAME_PIPE"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(DAI_PERIODS,
@@ -106,6 +124,9 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Playback PCM_I
 #
 
 PCM_CAPABILITIES(Passthrough Playback PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), PCM_MIN_RATE, PCM_MAX_RATE, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
+
+undefine(`CA_SWITCH_NAME_PIPE')
+undefine(`CA_SWITCH_NAME')
 
 undefine(`CA_SETUP_CONTROLBYTES_NAME_PIPE')
 undefine(`CA_SETUP_PARAMS')

--- a/tools/topology/topology1/sof/pipe-waves-codec-playback.m4
+++ b/tools/topology/topology1/sof/pipe-waves-codec-playback.m4
@@ -23,6 +23,7 @@ define(`CA_SETUP_CONTROLBYTES',
 )
 define(`CA_SETUP_CONTROLBYTES_MAX', 8192)
 define(`CA_SETUP_CONTROLBYTES_NAME', `Waves' `ENDPOINT_NAME' `Setup ')
+define(`CA_SWITCH_NAME', `Waves' `ENDPOINT_NAME' `Enable ')
 
 define(`CA_SCHEDULE_CORE', 0)
 


### PR DESCRIPTION
Consider adding a switch control on module_adapter for Waves CTC toggling.
It is way more robust to toggle states via a switch control than a bytes control.

This commit is the practice example. It is not verified yet as my device is getting some unexpected license problems today.

On the other hand, I think it is also worth a try in advance that aligning the bytes config setting logic as https://github.com/thesofproject/sof/blob/main/src/audio/google/google_ctc_audio_processing.c#L437
That is, when a new bytes config is delivered via apply_config(), it can be deferred to the next process() routine to be taken by MaxxChrome, instead of taking it promptly.